### PR TITLE
Feature/MountedViewsProvider

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -90,6 +90,12 @@ const Examples: ActionItem[] = [
     icon: '3d-glasses',
   },
   {
+    name: 'Mounted Views Provider',
+    component: lazy(() => import('./examples/MountedViews')),
+    code: () => import('./examples/MountedViews?raw'),
+    icon: 'collection',
+  },
+  {
     name: 'Custom Zoom Component',
     component: lazy(() => import('./examples/CustomZoom')),
     code: () => import('./examples/CustomZoom?raw'),

--- a/apps/web/src/examples/BasemapPicker.tsx
+++ b/apps/web/src/examples/BasemapPicker.tsx
@@ -1,6 +1,11 @@
 import Basemap from '@arcgis/core/Basemap';
 import { CalciteOption, CalciteSelect } from '@esri/calcite-components-react';
-import { ArcMapView, ArcUI, useArcState, useMapView } from 'arcgis-react';
+import {
+  ArcMapView,
+  ArcUI,
+  useArcState,
+  useCurrentMapView,
+} from 'arcgis-react';
 
 export default function Example() {
   return (
@@ -23,7 +28,7 @@ export default function Example() {
  * only render its children when the view is defined.
  */
 function BasemapPicker() {
-  const mapView = useMapView();
+  const mapView = useCurrentMapView();
   const [basemap, setBasemap] = useArcState(mapView.map, 'basemap');
 
   return (

--- a/apps/web/src/examples/CustomZoom.tsx
+++ b/apps/web/src/examples/CustomZoom.tsx
@@ -6,8 +6,7 @@ import {
 import {
   ArcMapView,
   ArcUI,
-  useArcState,
-  useMapView,
+  useCurrentMapView,
   useWatchState,
 } from 'arcgis-react';
 import { useMemo } from 'react';
@@ -32,7 +31,7 @@ export default function Example() {
 }
 
 function CustomZoom() {
-  const mapView = useMapView();
+  const mapView = useCurrentMapView();
   const widget = useMemo(() => new ZoomVM({ view: mapView }), [mapView]);
 
   const canZoomIn = useWatchState(() => widget.canZoomIn) ?? false;

--- a/apps/web/src/examples/IntroToLayers.tsx
+++ b/apps/web/src/examples/IntroToLayers.tsx
@@ -3,7 +3,12 @@ import {
   CalciteLabel,
   CalciteSwitch,
 } from '@esri/calcite-components-react';
-import { ArcMapView, ArcTileLayer, ArcUI, useMapView } from 'arcgis-react';
+import {
+  ArcMapView,
+  ArcTileLayer,
+  ArcUI,
+  useCurrentMapView,
+} from 'arcgis-react';
 import React from 'react';
 
 export default function Example() {
@@ -21,7 +26,7 @@ export default function Example() {
 }
 
 function Layers() {
-  const mapView = useMapView();
+  const mapView = useCurrentMapView();
 
   const [streetsVisible, setStreetsVisible] = React.useState(false);
 

--- a/apps/web/src/examples/MountedViews.tsx
+++ b/apps/web/src/examples/MountedViews.tsx
@@ -1,25 +1,19 @@
-import Basemap from '@arcgis/core/Basemap';
+import { CalciteBlock } from '@esri/calcite-components-react';
 import {
-  CalciteBlock,
-  CalciteLabel,
-  CalciteOption,
-  CalciteSelect,
-} from '@esri/calcite-components-react';
-import {
+  ArcBasemapGallery,
   ArcMapView,
   ArcSceneView,
   MountedViewsProvider,
-  useArcState,
-  useMountedViews,
+  useView,
 } from 'arcgis-react';
 
 export default function Example() {
   return (
     <MountedViewsProvider>
-      <div style={{ height: '60%', display: 'flex' }}>
+      <div style={{ height: '50%', display: 'flex' }}>
         {/* Map View */}
         <ArcMapView
-          id="my-map-view"
+          id="myMapView"
           style={{ flex: 1 }}
           map={{ basemap: 'streets' }}
           zoom={3}
@@ -28,7 +22,7 @@ export default function Example() {
 
         {/* Scene View */}
         <ArcSceneView
-          id="my-scene-view"
+          id="mySceneView"
           style={{ flex: 1 }}
           map={{ basemap: 'streets' }}
           camera={{
@@ -38,57 +32,29 @@ export default function Example() {
           }}
         />
       </div>
-
-      {/**
-       * Basemap Picker - outside of components directly rendering
-       * a Map or Scene
-       */}
       <BaseMapPickList />
     </MountedViewsProvider>
   );
 }
 
+/**
+ * Basemap Picker - used outside of components directly rendering
+ * a Map or Scene
+ */
 function BaseMapPickList() {
-  const views = useMountedViews();
-  if (!views) return null;
-
+  const { mySceneView, myMapView } = useView();
   return (
-    <CalciteBlock heading="Basemap options" open>
-      {Object.entries(views).map(([id, view]) => {
-        if (!view) return null;
-
-        return (
-          <BasemapPicker key={id} label={`Set Basemap for ${id}`} view={view} />
-        );
-      })}
-    </CalciteBlock>
-  );
-}
-
-function BasemapPicker({
-  view,
-  label,
-}: {
-  view: __esri.MapView | __esri.SceneView;
-  label: string;
-}) {
-  const [basemap, setBasemap] = useArcState(view.map, 'basemap');
-  console.log(basemap.id);
-
-  return (
-    <CalciteLabel>
-      {label}
-      <CalciteSelect
-        label="Basemap"
-        value={basemap.id}
-        onCalciteSelectChange={(e) =>
-          setBasemap(Basemap.fromId(e.target.value))
-        }
-      >
-        <CalciteOption value="streets">Streets</CalciteOption>
-        <CalciteOption value="terrain">Terrain</CalciteOption>
-        <CalciteOption value="dark-gray-vector">Dark Gray Vector</CalciteOption>
-      </CalciteSelect>
-    </CalciteLabel>
+    <div style={{ height: '50%', overflow: 'auto' }}>
+      {myMapView && (
+        <CalciteBlock heading="Map Basemaps" collapsible>
+          <ArcBasemapGallery view={myMapView} />
+        </CalciteBlock>
+      )}
+      {mySceneView && (
+        <CalciteBlock heading="Scene Basemaps" collapsible>
+          <ArcBasemapGallery view={mySceneView} />
+        </CalciteBlock>
+      )}
+    </div>
   );
 }

--- a/apps/web/src/examples/MountedViews.tsx
+++ b/apps/web/src/examples/MountedViews.tsx
@@ -3,13 +3,13 @@ import {
   ArcBasemapGallery,
   ArcMapView,
   ArcSceneView,
-  MountedViewsProvider,
+  ArcViewProvider,
   useView,
 } from 'arcgis-react';
 
 export default function Example() {
   return (
-    <MountedViewsProvider>
+    <ArcViewProvider>
       <div style={{ height: '50%', display: 'flex' }}>
         {/* Map View */}
         <ArcMapView
@@ -33,7 +33,7 @@ export default function Example() {
         />
       </div>
       <BaseMapPickList />
-    </MountedViewsProvider>
+    </ArcViewProvider>
   );
 }
 

--- a/apps/web/src/examples/MountedViews.tsx
+++ b/apps/web/src/examples/MountedViews.tsx
@@ -1,0 +1,93 @@
+import Basemap from '@arcgis/core/Basemap';
+import {
+  CalciteBlock,
+  CalciteLabel,
+  CalciteOption,
+  CalciteSelect,
+} from '@esri/calcite-components-react';
+import {
+  ArcMapView,
+  ArcSceneView,
+  MountedViewsProvider,
+  useArcState,
+  useMountedViews,
+} from 'arcgis-react';
+
+export default function Example() {
+  return (
+    <MountedViewsProvider>
+      <div style={{ height: '60%', display: 'flex' }}>
+        {/* Map View */}
+        <ArcMapView
+          id="my-map-view"
+          style={{ flex: 1 }}
+          map={{ basemap: 'dark-gray-vector' }}
+          zoom={3}
+          center={[-100.4593, 36.9014]}
+        />
+
+        {/* Scene View */}
+        <ArcSceneView
+          id="my-scene-view"
+          style={{ flex: 1 }}
+          map={{ basemap: 'streets-vector' }}
+          camera={{
+            tilt: 45,
+            heading: 0,
+            position: { x: 0, y: 40, z: 1000000 },
+          }}
+        />
+      </div>
+
+      {/**
+       * Basemap Picker - outside of components directly rendering
+       * a Map or Scene
+       */}
+      <BaseMapPickList />
+    </MountedViewsProvider>
+  );
+}
+
+function BaseMapPickList() {
+  const views = useMountedViews();
+  if (!views) return null;
+
+  return (
+    <CalciteBlock heading="Basemap options" open>
+      {Object.entries(views).map(([id, view]) => {
+        if (!view) return null;
+
+        return (
+          <BasemapPicker key={id} label={`Set Basemap for ${id}`} view={view} />
+        );
+      })}
+    </CalciteBlock>
+  );
+}
+
+function BasemapPicker({
+  view,
+  label,
+}: {
+  view: __esri.MapView | __esri.SceneView;
+  label: string;
+}) {
+  const [basemap, setBasemap] = useArcState(view.map, 'basemap');
+
+  return (
+    <CalciteLabel>
+      {label}
+      <CalciteSelect
+        label="Basemap"
+        value={basemap.id}
+        onCalciteSelectChange={(e) =>
+          setBasemap(Basemap.fromId(e.target.value))
+        }
+      >
+        <CalciteOption value="streets">Streets</CalciteOption>
+        <CalciteOption value="terrain">Terrain</CalciteOption>
+        <CalciteOption value="dark-gray-vector">Dark Gray Vector</CalciteOption>
+      </CalciteSelect>
+    </CalciteLabel>
+  );
+}

--- a/apps/web/src/examples/MountedViews.tsx
+++ b/apps/web/src/examples/MountedViews.tsx
@@ -21,7 +21,7 @@ export default function Example() {
         <ArcMapView
           id="my-map-view"
           style={{ flex: 1 }}
-          map={{ basemap: 'dark-gray-vector' }}
+          map={{ basemap: 'streets' }}
           zoom={3}
           center={[-100.4593, 36.9014]}
         />
@@ -30,7 +30,7 @@ export default function Example() {
         <ArcSceneView
           id="my-scene-view"
           style={{ flex: 1 }}
-          map={{ basemap: 'streets-vector' }}
+          map={{ basemap: 'streets' }}
           camera={{
             tilt: 45,
             heading: 0,
@@ -73,6 +73,7 @@ function BasemapPicker({
   label: string;
 }) {
   const [basemap, setBasemap] = useArcState(view.map, 'basemap');
+  console.log(basemap.id);
 
   return (
     <CalciteLabel>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "arcgis-react-utils",
+  "name": "arcgis-react",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/packages/arcgis-react/components/ArcView/ArcViewContext.tsx
+++ b/packages/arcgis-react/components/ArcView/ArcViewContext.tsx
@@ -16,11 +16,11 @@ type MountedViewsContextValue = {
   onViewUnmount: (id: string) => void;
 };
 
-export const MountedViewsContext = createContext<
+export const ArcViewContext = createContext<
   MountedViewsContextValue | undefined
 >(undefined);
 
-export const MountedViewsProvider = ({ children }: React.PropsWithChildren) => {
+export const ArcViewProvider = ({ children }: React.PropsWithChildren) => {
   const [views, setViews] = useState<{ [id: string]: MapView | SceneView }>({});
 
   const onViewMount = useCallback((view: MapView | SceneView, id: string) => {
@@ -47,7 +47,7 @@ export const MountedViewsProvider = ({ children }: React.PropsWithChildren) => {
   }, []);
 
   return (
-    <MountedViewsContext.Provider
+    <ArcViewContext.Provider
       value={{
         views,
         onViewMount,
@@ -55,7 +55,7 @@ export const MountedViewsProvider = ({ children }: React.PropsWithChildren) => {
       }}
     >
       {children}
-    </MountedViewsContext.Provider>
+    </ArcViewContext.Provider>
   );
 };
 
@@ -65,11 +65,11 @@ type ViewCollection = {
 };
 
 export function useView(): ViewCollection {
-  const views = useContext(MountedViewsContext)?.views;
+  const views = useContext(ArcViewContext)?.views;
   const currentView = useContext(MapContext);
 
   if (!views && !currentView) {
-    throw new Error('useMountedViews must be used within a valid Provider');
+    throw new Error('useView must be used within a valid Provider');
   }
 
   const mapsWithCurrent: ViewCollection = useMemo(

--- a/packages/arcgis-react/components/ArcView/MountedViewsContext.tsx
+++ b/packages/arcgis-react/components/ArcView/MountedViewsContext.tsx
@@ -1,0 +1,81 @@
+import MapView from '@arcgis/core/views/MapView';
+import SceneView from '@arcgis/core/views/SceneView';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
+
+import { MapContext } from './ViewContext';
+
+type MountedViewsContextValue = {
+  views: { [id: string]: MapView | SceneView };
+  onViewMount: (map: MapView | SceneView, id: string) => void;
+  onViewUnmount: (id: string) => void;
+};
+
+export const MountedViewsContext = createContext<
+  MountedViewsContextValue | undefined
+>(undefined);
+
+export const MountedViewsProvider = ({ children }: React.PropsWithChildren) => {
+  const [view, setViews] = useState<{ [id: string]: MapView | SceneView }>({});
+
+  const onMapMount = useCallback((view: MapView | SceneView, id: string) => {
+    setViews((currViews) => {
+      if (id === 'current') {
+        throw new Error("'current' cannot be used as map id");
+      }
+      if (currViews[id]) {
+        throw new Error(`Multiple maps with the same id: ${id}`);
+      }
+      return { ...currViews, [id]: view };
+    });
+  }, []);
+
+  const onMapUnmount = useCallback((id: string) => {
+    setViews((currViews) => {
+      if (currViews[id]) {
+        const nextViews = { ...currViews };
+        delete nextViews[id];
+        return nextViews;
+      }
+      return currViews;
+    });
+  }, []);
+
+  return (
+    <MountedViewsContext.Provider
+      value={{
+        views: view,
+        onViewMount: onMapMount,
+        onViewUnmount: onMapUnmount,
+      }}
+    >
+      {children}
+    </MountedViewsContext.Provider>
+  );
+};
+
+export type ViewCollection = {
+  [id: string]: MapView | SceneView | undefined;
+  current?: MapView | SceneView;
+};
+
+export function useMountedViews(): ViewCollection {
+  const views = useContext(MountedViewsContext)?.views;
+  const currentView = useContext(MapContext);
+
+  if (!views && !currentView) {
+    throw new Error('useMap must be used within a MapProvider');
+  }
+
+  const mapsWithCurrent: ViewCollection = useMemo(
+    () => ({ ...views, current: currentView }),
+    [views, currentView]
+  );
+
+  return mapsWithCurrent;
+}

--- a/packages/arcgis-react/components/ArcView/MountedViewsContext.tsx
+++ b/packages/arcgis-react/components/ArcView/MountedViewsContext.tsx
@@ -8,7 +8,7 @@ import {
   useState,
 } from 'react';
 
-import { MapContext } from './ViewContext';
+import { MapContext } from '../util/createView';
 
 type MountedViewsContextValue = {
   views: { [id: string]: MapView | SceneView };
@@ -64,7 +64,7 @@ type ViewCollection = {
   current?: MapView | SceneView;
 };
 
-export function useMountedViews(): ViewCollection {
+export function useView(): ViewCollection {
   const views = useContext(MountedViewsContext)?.views;
   const currentView = useContext(MapContext);
 

--- a/packages/arcgis-react/components/ArcView/MountedViewsContext.tsx
+++ b/packages/arcgis-react/components/ArcView/MountedViewsContext.tsx
@@ -21,9 +21,9 @@ export const MountedViewsContext = createContext<
 >(undefined);
 
 export const MountedViewsProvider = ({ children }: React.PropsWithChildren) => {
-  const [view, setViews] = useState<{ [id: string]: MapView | SceneView }>({});
+  const [views, setViews] = useState<{ [id: string]: MapView | SceneView }>({});
 
-  const onMapMount = useCallback((view: MapView | SceneView, id: string) => {
+  const onViewMount = useCallback((view: MapView | SceneView, id: string) => {
     setViews((currViews) => {
       if (id === 'current') {
         throw new Error("'current' cannot be used as map id");
@@ -35,7 +35,7 @@ export const MountedViewsProvider = ({ children }: React.PropsWithChildren) => {
     });
   }, []);
 
-  const onMapUnmount = useCallback((id: string) => {
+  const onViewUnmount = useCallback((id: string) => {
     setViews((currViews) => {
       if (currViews[id]) {
         const nextViews = { ...currViews };
@@ -49,9 +49,9 @@ export const MountedViewsProvider = ({ children }: React.PropsWithChildren) => {
   return (
     <MountedViewsContext.Provider
       value={{
-        views: view,
-        onViewMount: onMapMount,
-        onViewUnmount: onMapUnmount,
+        views,
+        onViewMount,
+        onViewUnmount,
       }}
     >
       {children}

--- a/packages/arcgis-react/components/ArcView/MountedViewsContext.tsx
+++ b/packages/arcgis-react/components/ArcView/MountedViewsContext.tsx
@@ -59,7 +59,7 @@ export const MountedViewsProvider = ({ children }: React.PropsWithChildren) => {
   );
 };
 
-export type ViewCollection = {
+type ViewCollection = {
   [id: string]: MapView | SceneView | undefined;
   current?: MapView | SceneView;
 };
@@ -69,7 +69,7 @@ export function useMountedViews(): ViewCollection {
   const currentView = useContext(MapContext);
 
   if (!views && !currentView) {
-    throw new Error('useMap must be used within a MapProvider');
+    throw new Error('useMountedViews must be used within a valid Provider');
   }
 
   const mapsWithCurrent: ViewCollection = useMemo(

--- a/packages/arcgis-react/components/ArcView/ViewContext.tsx
+++ b/packages/arcgis-react/components/ArcView/ViewContext.tsx
@@ -1,7 +1,7 @@
 import type MapView from '@arcgis/core/views/MapView';
 import type SceneView from '@arcgis/core/views/SceneView';
 
-import { useView } from './MountedViewsContext';
+import { useView } from './ArcViewContext';
 
 export function useCurrentView(
   defaultView?: MapView | SceneView

--- a/packages/arcgis-react/components/ArcView/ViewContext.tsx
+++ b/packages/arcgis-react/components/ArcView/ViewContext.tsx
@@ -1,36 +1,33 @@
 import type MapView from '@arcgis/core/views/MapView';
 import type SceneView from '@arcgis/core/views/SceneView';
-import { createContext, useContext } from 'react';
 
-export const MapContext = createContext<MapView | SceneView | undefined>(
-  undefined
-);
+import { useView } from './MountedViewsContext';
 
-export function useView(
+export function useCurrentView(
   defaultView?: MapView | SceneView
 ): MapView | SceneView {
-  const view = useContext(MapContext);
+  const { current: view } = useView();
 
   if (!view) {
     if (defaultView) return defaultView;
-    throw new Error(`useView must be used in a MapContext`);
+    throw new Error(`useCurrentView must be used in a MapContext`);
   }
 
   return view;
 }
 
-export function useMapView(): MapView {
-  const view = useView();
+export function useCurrentMapView(): MapView {
+  const view = useCurrentView();
   if (view.type === '3d')
-    throw new Error(`useMapView must be used within a 2D MapContext`);
+    throw new Error(`useCurrentMapView must be used within a 2D MapContext`);
 
   return view;
 }
 
-export function useSceneView(): SceneView {
-  const view = useView();
+export function useCurrentSceneView(): SceneView {
+  const view = useCurrentView();
   if (view.type === '2d')
-    throw new Error(`useSceneView must be used within a 3D MapContext`);
+    throw new Error(`useCurrentSceneView must be used within a 3D MapContext`);
 
   return view;
 }

--- a/packages/arcgis-react/components/util/createLayer.tsx
+++ b/packages/arcgis-react/components/util/createLayer.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 
 import { useEventHandlers } from '../../hooks/useEventHandlers';
 import { EventHandlers } from '../../typings/EsriTypes';
-import { useView } from '../ArcView/ViewContext';
+import { useCurrentView } from '../ArcView/ViewContext';
 import { ArcReactiveProp } from './ArcReactiveProp';
 
 export function createLayer<
@@ -22,7 +22,7 @@ export function createLayer<
     eventHandlers?: EventHandlers<LayerInstance>;
     children?: React.ReactNode;
   } & LayerProperties) {
-    const mapView = useView();
+    const mapView = useCurrentView();
     const [layer, setLayer] = useState<LayerInstance>();
     const [layerView, setLayerView] = useState<__esri.LayerView>();
 

--- a/packages/arcgis-react/components/util/createView.tsx
+++ b/packages/arcgis-react/components/util/createView.tsx
@@ -26,7 +26,6 @@ export function createViewComponent<
     onViewCreated,
     style,
     className,
-    id,
     map,
     eventHandlers,
     ...mapViewProps
@@ -49,6 +48,8 @@ export function createViewComponent<
     const mapContainer = useRef<HTMLDivElement>(null);
 
     const internalId = useId();
+    const id = mapViewProps.id ?? internalId;
+
     const mountedViewsContext = useContext(MountedViewsContext);
     const { onViewMount, onViewUnmount } = mountedViewsContext ?? {};
 
@@ -59,25 +60,20 @@ export function createViewComponent<
         onViewCreated?.(mapView as View);
       });
 
-      onViewMount?.(mapView, id ?? internalId);
+      onViewMount?.(mapView, id);
 
       return () => {
         // @ts-expect-error - container types are wrong
         mapView.container = undefined;
-        onViewUnmount?.(id ?? internalId);
+        onViewUnmount?.(id);
       };
-    }, [mapView, onViewCreated, id, internalId, onViewMount, onViewUnmount]);
+    }, [mapView, onViewCreated, id, onViewMount, onViewUnmount]);
 
     useEventHandlers(mapView, eventHandlers);
 
     return (
       <MapContext.Provider value={mapView}>
-        <div
-          ref={mapContainer}
-          id={id ?? internalId}
-          style={style}
-          className={className}
-        >
+        <div ref={mapContainer} id={id} style={style} className={className}>
           {mapView && children}
         </div>
         {Object.entries(mapViewProps).map(([key, value]) => {

--- a/packages/arcgis-react/components/util/createView.tsx
+++ b/packages/arcgis-react/components/util/createView.tsx
@@ -1,5 +1,8 @@
+import MapView from '@arcgis/core/views/MapView';
+import SceneView from '@arcgis/core/views/SceneView';
 import WebMap from '@arcgis/core/WebMap';
 import React, {
+  createContext,
   memo,
   useContext,
   useEffect,
@@ -11,9 +14,12 @@ import React, {
 import { useEventHandlers } from '../../hooks/useEventHandlers';
 import { ArcViewWrapperProps, EsriView } from '../../typings/EsriTypes';
 import { MountedViewsContext } from '../ArcView/MountedViewsContext';
-import { MapContext } from '../ArcView/ViewContext';
 import { ArcReactiveProp } from './ArcReactiveProp';
 import { isEqual } from './isEqual';
+
+export const MapContext = createContext<MapView | SceneView | undefined>(
+  undefined
+);
 
 export function createViewComponent<
   ViewConstructor extends EsriView,

--- a/packages/arcgis-react/components/util/createView.tsx
+++ b/packages/arcgis-react/components/util/createView.tsx
@@ -13,7 +13,7 @@ import React, {
 
 import { useEventHandlers } from '../../hooks/useEventHandlers';
 import { ArcViewWrapperProps, EsriView } from '../../typings/EsriTypes';
-import { MountedViewsContext } from '../ArcView/MountedViewsContext';
+import { ArcViewContext } from '../ArcView/ArcViewContext';
 import { ArcReactiveProp } from './ArcReactiveProp';
 import { isEqual } from './isEqual';
 
@@ -56,7 +56,7 @@ export function createViewComponent<
     const internalId = useId();
     const id = mapViewProps.id ?? internalId;
 
-    const mountedViewsContext = useContext(MountedViewsContext);
+    const mountedViewsContext = useContext(ArcViewContext);
     const { onViewMount, onViewUnmount } = mountedViewsContext ?? {};
 
     useEffect(() => {

--- a/packages/arcgis-react/components/util/createWidget.tsx
+++ b/packages/arcgis-react/components/util/createWidget.tsx
@@ -2,7 +2,7 @@ import { memo, useEffect, useRef, useState } from 'react';
 
 import { useEventHandlers } from '../../hooks/useEventHandlers';
 import { EventHandlers } from '../../typings/EsriTypes';
-import { useView } from '../ArcView/ViewContext';
+import { useCurrentView } from '../ArcView/ViewContext';
 import { ArcReactiveProp } from './ArcReactiveProp';
 import { isEqual } from './isEqual';
 
@@ -25,7 +25,7 @@ export function createWidget<
       view?: __esri.SceneView | __esri.MapView;
     }) {
     const ref = useRef<HTMLDivElement>(null);
-    const view = useView(propsView);
+    const view = useCurrentView(propsView);
     const [widget] = useState<WidgetInstance>(
       new WidgetConstructor(widgetProps as WidgetProperties)
     );

--- a/packages/arcgis-react/hooks/useArcUI.tsx
+++ b/packages/arcgis-react/hooks/useArcUI.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useRef } from 'react';
 
-import { useView } from '../components/ArcView/ViewContext';
+import { useCurrentView } from '../components/ArcView/ViewContext';
 
 export const useArcUI = (position: __esri.UIAddPosition['position']) => {
   const widgetRef = useRef<HTMLDivElement>(null);
-  const view = useView();
+  const view = useCurrentView();
 
   useEffect(() => {
     const ref = widgetRef.current;

--- a/packages/arcgis-react/index.tsx
+++ b/packages/arcgis-react/index.tsx
@@ -42,6 +42,10 @@ export { ArcUI } from './components/ArcUI/ArcUI';
 export { ArcMapView } from './components/ArcView/ArcMapView';
 export { ArcSceneView } from './components/ArcView/ArcSceneView';
 export {
+  MountedViewsProvider,
+  useMountedViews,
+} from './components/ArcView/MountedViewsContext';
+export {
   useMapView,
   useSceneView,
   useView,

--- a/packages/arcgis-react/index.tsx
+++ b/packages/arcgis-react/index.tsx
@@ -43,12 +43,12 @@ export { ArcMapView } from './components/ArcView/ArcMapView';
 export { ArcSceneView } from './components/ArcView/ArcSceneView';
 export {
   MountedViewsProvider,
-  useMountedViews,
+  useView,
 } from './components/ArcView/MountedViewsContext';
 export {
-  useMapView,
-  useSceneView,
-  useView,
+  useCurrentMapView,
+  useCurrentSceneView,
+  useCurrentView,
 } from './components/ArcView/ViewContext';
 export { ArcAreaMeasurement2D } from './components/ArcWidget/generated/ArcAreaMeasurement2D';
 export { ArcAreaMeasurement3D } from './components/ArcWidget/generated/ArcAreaMeasurement3D';

--- a/packages/arcgis-react/index.tsx
+++ b/packages/arcgis-react/index.tsx
@@ -41,10 +41,7 @@ export { ArcWMTSLayer } from './components/ArcLayer/generated/ArcWMTSLayer';
 export { ArcUI } from './components/ArcUI/ArcUI';
 export { ArcMapView } from './components/ArcView/ArcMapView';
 export { ArcSceneView } from './components/ArcView/ArcSceneView';
-export {
-  MountedViewsProvider,
-  useView,
-} from './components/ArcView/MountedViewsContext';
+export { ArcViewProvider, useView } from './components/ArcView/ArcViewContext';
 export {
   useCurrentMapView,
   useCurrentSceneView,

--- a/packages/arcgis-react/typings/EsriTypes.ts
+++ b/packages/arcgis-react/typings/EsriTypes.ts
@@ -36,5 +36,6 @@ export type ArcViewWrapperProps<
   onViewCreated?: (view: View) => void;
   style?: React.CSSProperties;
   className?: string;
+  id?: string;
   eventHandlers?: EventHandlers<View>;
 } & Properties;


### PR DESCRIPTION
reference: #11 

# Description
This pull request introduces a new MountedViewsProvider component, allowing users to seamlessly access Views outside of the component that directly renders the map. The MapProvider wraps all nodes where map access is desired.

# Changes Made
- Added a new MountedViewsProvider component.
- The MountedViewsProvider component can be used to wrap nodes where map access is needed.
- The implementation follows a pattern similar to the example in [visgl/react-map-gl](https://visgl.github.io/react-map-gl/docs/api-reference/map-provider), with adaptations to match the specific patterns of this project.
- Added a example.

Very happy for changes and feedback!
