### PR TITLE
Update ArcSearch typings to use correct properties

### DIFF
--- a/packages/arcgis-react/components/ArcWidget/generated/ArcSearch.tsx
+++ b/packages/arcgis-react/components/ArcWidget/generated/ArcSearch.tsx
@@ -2,8 +2,7 @@ import Search from '@arcgis/core/widgets/Search';
 
 import { createWidget } from '../../util/createWidget';
 export const ArcSearch = createWidget<
-  // @ts-expect-error - Search is not typed correctly
   typeof Search,
-  __esri.SearchProperties,
+  __esri.widgetsSearchProperties,
   Search
 >(Search);


### PR DESCRIPTION
A small fix to update the Search widget typings. There was a previous note that the Esri typings were incorrect - has this been superseded by a change on their end, or is there a reason why this fix isn't sufficient? 

I've tested it in another application and it has resolved my types issues. 